### PR TITLE
feat(conformance): add conformance image

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -11,6 +11,7 @@ policies:
     - style
     - test
     scopes:
+    - conformance
     - image
     - init
     - initramfs

--- a/src/conformance/.conform.yaml
+++ b/src/conformance/.conform.yaml
@@ -1,0 +1,23 @@
+metadata:
+  repository: dianemo/conformance
+  variables:
+    srcKubectl: https://storage.googleapis.com/kubernetes-release/release/v1.11.1/bin/linux/amd64/kubectl
+    srcSonobuoy: https://github.com/heptio/sonobuoy/releases/download/v0.11.4/sonobuoy_0.11.4_linux_amd64.tar.gz
+pipeline:
+  stages:
+  - test
+stages:
+  test:
+    tasks:
+    - sonobuoy
+tasks:
+  sonobuoy:
+    template: |
+      FROM alpine:3.7
+      RUN apk --no-cache add curl tar
+      RUN curl --retry 3 --retry-delay 60 -L {{ index .Variables "srcKubectl" }} -o /bin/kubectl
+      RUN chmod +x /bin/kubectl
+      RUN curl --retry 3 --retry-delay 60 -L {{ index .Variables "srcSonobuoy" }} | tar -xz -C /bin
+      COPY ./src/sonobuoy.yaml /etc/sonobuoy/sonobuoy.yaml
+      ENTRYPOINT ["/bin/sonobuoy"]
+      CMD ["run", "--config=/etc/sonobuoy/sonobuoy.yaml"]

--- a/src/conformance/src/sonobuoy.yaml
+++ b/src/conformance/src/sonobuoy.yaml
@@ -1,0 +1,172 @@
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: heptio-sonobuoy
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+  namespace: heptio-sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount-heptio-sonobuoy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: sonobuoy-serviceaccount
+subjects:
+- kind: ServiceAccount
+  name: sonobuoy-serviceaccount
+  namespace: heptio-sonobuoy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-serviceaccount
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: v1
+data:
+  config.json: |
+    {"Description":"DEFAULT","UUID":"3cdfd89f-30c7-4872-9ed5-fcba4fae1616","Version":"v0.11.4","ResultsDir":"/tmp/sonobuoy","Resources":["CertificateSigningRequests","ClusterRoleBindings","ClusterRoles","ComponentStatuses","CustomResourceDefinitions","Nodes","PersistentVolumes","PodSecurityPolicies","ServerGroups","ServerVersion","StorageClasses","ConfigMaps","ControllerRevisions","CronJobs","DaemonSets","Deployments","Endpoints","Ingresses","Jobs","LimitRanges","NetworkPolicies","PersistentVolumeClaims","PodDisruptionBudgets","PodTemplates","Pods","ReplicaSets","ReplicationControllers","ResourceQuotas","RoleBindings","Roles","ServiceAccounts","Services","StatefulSets"],"Filters":{"Namespaces":".*","LabelSelector":""},"Limits":{"PodLogs":{"LimitSize":"","LimitTime":""}},"Server":{"bindaddress":"0.0.0.0","bindport":8080,"advertiseaddress":"","timeoutseconds":10800},"Plugins":[{"name":"e2e"}],"PluginSearchPath":["./plugins.d","/etc/sonobuoy/plugins.d","~/sonobuoy/plugins.d"],"Namespace":"heptio-sonobuoy","LoadedPlugins":null,"WorkerImage":"gcr.io/heptio-images/sonobuoy:latest","ImagePullPolicy":"Always"}
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-config-cm
+  namespace: heptio-sonobuoy
+---
+apiVersion: v1
+data:
+  e2e.yaml: |
+    sonobuoy-config:
+      driver: Job
+      plugin-name: e2e
+      result-type: e2e
+    spec:
+      env:
+      - name: E2E_FOCUS
+        value: '\[Conformance\]'
+      - name: E2E_SKIP
+        value: 'Alpha|Kubectl|\[(Disruptive|Feature:[^\]]+|Flaky)\]'
+      - name: E2E_PARALLEL
+        value: '1'
+      command: ["/run_e2e.sh"]
+      image: gcr.io/heptio-images/kube-conformance:latest
+      imagePullPolicy: Always
+      name: e2e
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+        readOnly: false
+  systemd-logs.yaml: |
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: systemd-logs
+      result-type: systemd_logs
+    spec:
+      command: ["/bin/sh", "-c", "/get_systemd_logs.sh && sleep 3600"]
+      env:
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: CHROOT_DIR
+        value: /node
+      image: gcr.io/heptio-images/sonobuoy-plugin-systemd-logs:latest
+      imagePullPolicy: Always
+      name: sonobuoy-systemd-logs-config
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+        readOnly: false
+      - mountPath: /node
+        name: root
+        readOnly: false
+kind: ConfigMap
+metadata:
+  labels:
+    component: sonobuoy
+  name: sonobuoy-plugins-cm
+  namespace: heptio-sonobuoy
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+    tier: analysis
+  name: sonobuoy
+  namespace: heptio-sonobuoy
+spec:
+  containers:
+  - command:
+    - /bin/bash
+    - -c
+    - /sonobuoy master --no-exit=true -v 3 --logtostderr
+    env:
+    - name: SONOBUOY_ADVERTISE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    image: gcr.io/heptio-images/sonobuoy:v0.11.4
+    imagePullPolicy: Always
+    name: kube-sonobuoy
+    volumeMounts:
+    - mountPath: /etc/sonobuoy
+      name: sonobuoy-config-volume
+    - mountPath: /plugins.d
+      name: sonobuoy-plugins-volume
+    - mountPath: /tmp/sonobuoy
+      name: output-volume
+  restartPolicy: Never
+  serviceAccountName: sonobuoy-serviceaccount
+  volumes:
+  - configMap:
+      name: sonobuoy-config-cm
+    name: sonobuoy-config-volume
+  - configMap:
+      name: sonobuoy-plugins-cm
+    name: sonobuoy-plugins-volume
+  - emptyDir: {}
+    name: output-volume
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: sonobuoy
+    run: sonobuoy-master
+  name: sonobuoy-master
+  namespace: heptio-sonobuoy
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    run: sonobuoy-master
+  type: ClusterIP
+


### PR DESCRIPTION
We don't have CI in place yet, but this PR adds the build for the conformance image that we can run manually for now as part of the release process.

Note that we have to remove the `systemd_logs` plugin by editing the output of the `sonobuoy-config-cm` `ConfigMap` from `sonobuoy gen`.

Closes #102.